### PR TITLE
Make Division::zoom methods safer by returning an Option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "time_calc"
 description = "A library for music/DSP time conversions! Provides functions and methods for converting between ticks, ms, samples, bars, beats and measures."
-version = "0.9.13"
+version = "0.10.0"
 authors = ["mitchell.nordine@gmail.com"]
 readme = "README.md"
 keywords = ["time", "dsp", "audio", "music", "conversion"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ repository = "https://github.com/RustAudio/time_calc.git"
 homepage = "https://github.com/RustAudio/time_calc"
 
 [dependencies]
-num = "*"
-rand = "*"
-rustc-serialize = "*"
+num = "0.1.27"
+rand = "0.3.11"
+rustc-serialize = "0.3.16"

--- a/src/division.rs
+++ b/src/division.rs
@@ -55,18 +55,24 @@ impl Division {
     }
 
     /// Zoom into a higher resolution division by the number of steps given.
-    pub fn zoom_in(&self, steps: u8) -> Division {
+    pub fn zoom_in(&self, steps: u8) -> Option<Division> {
         let zoom_step = self.to_u8() + steps;
-        assert!(zoom_step <= HIGHEST_ZOOM_STEP);
-        NumCast::from(zoom_step).unwrap()
+        if zoom_step <= HIGHEST_ZOOM_STEP {
+            Some(NumCast::from(zoom_step).unwrap())
+        } else {
+            None
+        }
     }
 
     /// Zoom into a higher resolution division by the number of steps given.
-    pub fn zoom_out(&self, steps: u8) -> Division {
+    pub fn zoom_out(&self, steps: u8) -> Option<Division> {
         let current_zoom_step = self.to_u8();
-        assert!(steps <= current_zoom_step);
-        let zoom_step = current_zoom_step - steps;
-        NumCast::from(zoom_step).unwrap()
+        if steps <= current_zoom_step {
+            let zoom_step = current_zoom_step - steps;
+            Some(NumCast::from(zoom_step).unwrap())
+        } else {
+            None
+        }
     }
 
     /// Convert a Division to its byte equivalent.


### PR DESCRIPTION
Updating to version 0.10.0 for breaking change.